### PR TITLE
Add full session management (drag & drop, create, update, delete) to planning for admin

### DIFF
--- a/src/components/planning/DragDropConfirmModal.tsx
+++ b/src/components/planning/DragDropConfirmModal.tsx
@@ -1,0 +1,103 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import Button from '@/components/Button'
+
+interface Props {
+  isOpen: boolean
+  data: {
+    originalStart: Date
+    originalEnd: Date
+    newStart: Date
+    newEnd: Date
+  } | null
+  isLoading?: boolean
+  error?: string | null
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+function formatDate(date: Date | null) {
+  if (!date) return ''
+  return date.toLocaleString('fr-FR', {
+    weekday: 'long',
+    day: '2-digit',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function DragDropConfirmModal({
+  isOpen,
+  data,
+  isLoading,
+  onConfirm,
+  onCancel,
+}: Props) {
+  return (
+    <AnimatePresence>
+      {isOpen && data && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
+          onClick={onCancel}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            className="bg-white rounded-xl shadow-xl w-full max-w-md mx-4 p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Close */}
+            <div className="flex justify-end">
+              <button
+                onClick={onCancel}
+                className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
+              >
+                <XMarkIcon className="size-5" />
+              </button>
+            </div>
+
+            {/* Title */}
+            <div className="text-center mb-6">
+              <h3 className="text-lg font-semibold text-gray-900">
+                Confirmer le changement de séance ?
+              </h3>
+
+              <p className="text-gray-500 mt-2">
+                Nouvelle plage horaire :
+              </p>
+
+              <div className="mt-3 text-sm font-medium text-gray-800 bg-gray-50 p-3 rounded-md">
+                {formatDate(data.newStart)} → {formatDate(data.newEnd)}
+              </div>
+            </div>
+
+            {/* Buttons */}
+            <div className="flex gap-3">
+              <Button
+                variant="outlined"
+                onClick={onCancel}
+                className="flex-1 border-gray-300 text-gray-700 hover:bg-gray-50"
+              >
+                Annuler
+              </Button>
+
+              <Button
+                onClick={onConfirm}
+                disabled={isLoading}
+                className="flex-1 bg-primary-900 hover:bg-primary-700"
+              >
+                Confirmer
+              </Button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/planning/PlanningCalendar.tsx
+++ b/src/components/planning/PlanningCalendar.tsx
@@ -8,6 +8,8 @@ import type {
   EventContentArg,
   DayHeaderContentArg,
   EventHoveringArg,
+  EventDropArg,
+  EventClickArg,
 } from '@fullcalendar/core'
 import {
   CalendarClock,
@@ -18,12 +20,52 @@ import {
   Tag,
   Text,
 } from 'lucide-react'
+import DragDropConfirmModal from './DragDropConfirmModal'
+import SessionDetailsModal from './SessionDetailsModal'
+import AddSessionModal from '@/components/sessions/AddSessionModal'
+import EditSessionModal from '@/components/sessions/EditSessionModal'
+import DeleteSessionModal from '@/components/sessions/DeleteSessionModal'
+import { type SessionWithGroup } from '@/types/session'
 import './planning-calendar.css'
 
 interface PlanningCalendarProps {
   selectedDate: Date
   events?: EventInput[]
   isLoading?: boolean
+  onEventDrop?: (arg: EventDropArg) => void
+  onEventClick?: (arg: EventClickArg) => void
+  onDoubleClick?: (startDate: Date, endDate: Date) => void // Double-click with time range
+  onEventDropForConfirmation?: (eventId: string, oldStart: Date, oldEnd: Date, newStart: Date, newEnd: Date) => Promise<void> // Drag with confirmation (async validation)
+  // Modal states
+  dragDropConfirmOpen?: boolean
+  dragDropData?: {
+    originalStart: Date
+    originalEnd: Date
+    newStart: Date
+    newEnd: Date
+  } | null
+  dragDropLoading?: boolean
+  dragDropError?: string | null
+  onConfirmDragDrop?: () => void
+  onCancelDragDrop?: () => void
+  sessionDetailsOpen?: boolean
+  selectedSession?: SessionWithGroup | null
+  onCloseSessionDetails?: () => void
+  onEditSession?: (session: SessionWithGroup) => void
+  onDeleteSessionFromDetails?: (session: SessionWithGroup) => void
+  addSessionOpen?: boolean
+  addSessionDefaultDate?: Date | null
+  addSessionDateRange?: { start: Date; end: Date } | null
+  onCloseAddSession?: () => void
+  onAddSession?: (values: any) => Promise<boolean>
+  editSessionOpen?: boolean
+  editTarget?: SessionWithGroup | null
+  onCloseEditSession?: () => void
+  onEditSession2?: (values: any) => Promise<boolean>
+  deleteConfirmOpen?: boolean
+  deleteTarget?: SessionWithGroup | null
+  onCloseDeleteConfirm?: () => void
+  onConfirmDelete?: () => void
 }
 
 interface PlanningTooltipData {
@@ -44,7 +86,9 @@ function renderEventContent(eventInfo: EventContentArg) {
   const subtitle = [course, room].filter(Boolean).join(' · ')
   return (
     <div className="p-1.5 h-full">
-      <p className="font-semibold text-sm leading-tight">{eventInfo.event.title}</p>
+      <p className="font-semibold text-sm leading-tight">
+        {eventInfo.event.title}
+      </p>
       {subtitle && (
         <p className="text-xs opacity-75 mt-0.5 truncate">{subtitle}</p>
       )}
@@ -96,10 +140,98 @@ function hasValue(value: string | null | undefined): value is string {
   return Boolean(value && value.trim().length > 0)
 }
 
-function PlanningCalendar({ selectedDate, events = [], isLoading }: PlanningCalendarProps) {
+function PlanningCalendar({
+  selectedDate,
+  events = [],
+  isLoading,
+  onEventDrop,
+  onEventClick,
+  dragDropConfirmOpen = false,
+  dragDropData = null,
+  dragDropLoading = false,
+  dragDropError = null,
+  onConfirmDragDrop,
+  onCancelDragDrop,
+  sessionDetailsOpen = false,
+  selectedSession = null,
+  onCloseSessionDetails,
+  onEditSession,
+  onDeleteSessionFromDetails,
+  addSessionOpen = false,
+  addSessionDefaultDate = null,
+  addSessionDateRange = null,
+  onCloseAddSession,
+  onAddSession,
+  editSessionOpen = false,
+  editTarget = null,
+  onCloseEditSession,
+  onEditSession2,
+  deleteConfirmOpen = false,
+  deleteTarget = null,
+  onCloseDeleteConfirm,
+  onConfirmDelete,
+  onDoubleClick,
+  onEventDropForConfirmation,
+}: PlanningCalendarProps) {
   const calendarRef = useRef<FullCalendar>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [tooltip, setTooltip] = useState<PlanningTooltipData | null>(null)
+
+  let clickTimer: any = null
+
+  const handleDateClick = (arg: any) => {
+    if (clickTimer) {
+      clearTimeout(clickTimer)
+      clickTimer = null
+
+      // 👉 DOUBLE CLICK detected
+      handleDoubleClick(arg)
+    } else {
+      clickTimer = setTimeout(() => {
+        clickTimer = null
+      }, 250)
+    }
+  }
+
+  const handleDoubleClick = (arg: any) => {
+    const start = new Date(arg.date)
+    // Snap to 15min if needed - round down to nearest 15min
+    const minutes = start.getMinutes() 
+    const remainder = minutes % 15
+    if (remainder !== 0) {
+      start.setMinutes(minutes + remainder)
+      start.setSeconds(0)
+    }
+    
+    // Default duration: 1h30 (90 minutes)
+    const end = new Date(start.getTime() + 90 * 60 * 1000)
+    
+    onDoubleClick?.(start, end)
+  }
+
+  const handleEventDropWithConfirmation = async (arg: EventDropArg) => {
+    const eventId = arg.event.id
+    const oldStart = arg.oldEvent.start
+    const oldEnd = arg.oldEvent.end
+    const newStart = arg.event.start
+    const newEnd = arg.event.end
+
+    if (!eventId || !oldStart || !oldEnd || !newStart || !newEnd) {
+      arg.revert()
+      return
+    }
+
+    // Revert event visually while we validate and wait for confirmation
+    arg.revert()
+
+    // If confirmation callback provided, use confirmation flow
+    if (onEventDropForConfirmation) {
+      await onEventDropForConfirmation(eventId, oldStart, oldEnd, newStart, newEnd)
+    } else {
+      // Otherwise, fall back to direct update (for backward compatibility)
+      onEventDrop?.(arg)
+    }
+  }
 
   useEffect(() => {
     if (calendarRef.current) {
@@ -134,13 +266,18 @@ function PlanningCalendar({ selectedDate, events = [], isLoading }: PlanningCale
   const tooltipStyle =
     tooltip && containerRef.current
       ? {
-          left: tooltip.x - containerRef.current.getBoundingClientRect().left + 12,
-          top: tooltip.y - containerRef.current.getBoundingClientRect().top + 12,
+          left:
+            tooltip.x - containerRef.current.getBoundingClientRect().left + 12,
+          top:
+            tooltip.y - containerRef.current.getBoundingClientRect().top + 12,
         }
       : undefined
 
   return (
-    <div ref={containerRef} className="planning-calendar flex-1 overflow-auto px-1 relative">
+    <div
+      ref={containerRef}
+      className="planning-calendar flex-1 overflow-auto px-1 relative"
+    >
       {isLoading && (
         <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60">
           <span className="loading loading-spinner loading-md" />
@@ -148,6 +285,8 @@ function PlanningCalendar({ selectedDate, events = [], isLoading }: PlanningCale
       )}
       <div className="min-w-[700px] h-full">
         <FullCalendar
+          selectable={true}
+          dateClick={handleDateClick}
           ref={calendarRef}
           plugins={[timeGridPlugin, interactionPlugin]}
           locale={frLocale}
@@ -157,6 +296,7 @@ function PlanningCalendar({ selectedDate, events = [], isLoading }: PlanningCale
           slotMinTime="08:00:00"
           slotMaxTime="20:00:00"
           slotDuration="01:00:00"
+          snapDuration="00:15:00"
           slotLabelInterval="01:00:00"
           slotLabelFormat={{
             hour: 'numeric',
@@ -171,8 +311,10 @@ function PlanningCalendar({ selectedDate, events = [], isLoading }: PlanningCale
           eventContent={renderEventContent}
           eventMouseEnter={handleMouseEnter}
           eventMouseLeave={handleMouseLeave}
-          editable={false}
-          selectable={false}
+          editable={true}
+          eventDurationEditable={false}
+          eventDrop={handleEventDropWithConfirmation}
+          eventClick={onEventClick}
         />
       </div>
       {tooltip && tooltipStyle && (
@@ -180,64 +322,144 @@ function PlanningCalendar({ selectedDate, events = [], isLoading }: PlanningCale
           <p className="planning-tooltip-title">Details de la seance</p>
           {hasValue(formatDate(tooltip.start)) && (
             <div className="planning-tooltip-row">
-              <CalendarClock size={14} className="planning-tooltip-icon text-indigo-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--indigo">Date</span>
-              <span className="planning-tooltip-value">{formatDate(tooltip.start)}</span>
-            </div>
-          )}
-          {hasValue(formatTime(tooltip.start)) && hasValue(formatTime(tooltip.end)) && (
-            <div className="planning-tooltip-row">
-              <Clock3 size={14} className="planning-tooltip-icon text-violet-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--violet">Horaire</span>
+              <CalendarClock
+                size={14}
+                className="planning-tooltip-icon text-indigo-300"
+              />
+              <span className="planning-tooltip-tag planning-tooltip-tag--indigo">
+                Date
+              </span>
               <span className="planning-tooltip-value">
-                {formatTime(tooltip.start)} - {formatTime(tooltip.end)}
+                {formatDate(tooltip.start)}
               </span>
             </div>
           )}
+          {hasValue(formatTime(tooltip.start)) &&
+            hasValue(formatTime(tooltip.end)) && (
+              <div className="planning-tooltip-row">
+                <Clock3
+                  size={14}
+                  className="planning-tooltip-icon text-violet-300"
+                />
+                <span className="planning-tooltip-tag planning-tooltip-tag--violet">
+                  Horaire
+                </span>
+                <span className="planning-tooltip-value">
+                  {formatTime(tooltip.start)} - {formatTime(tooltip.end)}
+                </span>
+              </div>
+            )}
           {hasValue(tooltip.mode) && (
             <div className="planning-tooltip-row">
-              <Monitor size={14} className="planning-tooltip-icon text-blue-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--blue">Mode</span>
+              <Monitor
+                size={14}
+                className="planning-tooltip-icon text-blue-300"
+              />
+              <span className="planning-tooltip-tag planning-tooltip-tag--blue">
+                Mode
+              </span>
               <span className="planning-tooltip-value">{tooltip.mode}</span>
             </div>
           )}
           {hasValue(tooltip.type) && (
             <div className="planning-tooltip-row">
-              <Shapes size={14} className="planning-tooltip-icon text-emerald-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--emerald">Type</span>
+              <Shapes
+                size={14}
+                className="planning-tooltip-icon text-emerald-300"
+              />
+              <span className="planning-tooltip-tag planning-tooltip-tag--emerald">
+                Type
+              </span>
               <span className="planning-tooltip-value">{tooltip.type}</span>
             </div>
           )}
           {hasValue(tooltip.status) && (
             <div className="planning-tooltip-row">
               <Tag size={14} className="planning-tooltip-icon text-amber-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--amber">Status</span>
+              <span className="planning-tooltip-tag planning-tooltip-tag--amber">
+                Status
+              </span>
               <span className="planning-tooltip-value">{tooltip.status}</span>
             </div>
           )}
           {hasValue(tooltip.room) && (
             <div className="planning-tooltip-row">
-              <DoorOpen size={14} className="planning-tooltip-icon text-rose-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--rose">Salle</span>
+              <DoorOpen
+                size={14}
+                className="planning-tooltip-icon text-rose-300"
+              />
+              <span className="planning-tooltip-tag planning-tooltip-tag--rose">
+                Salle
+              </span>
               <span className="planning-tooltip-value">{tooltip.room}</span>
             </div>
           )}
           {hasValue(tooltip.course) && (
             <div className="planning-tooltip-row">
               <Text size={14} className="planning-tooltip-icon text-teal-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--teal">Cours</span>
+              <span className="planning-tooltip-tag planning-tooltip-tag--teal">
+                Cours
+              </span>
               <span className="planning-tooltip-value">{tooltip.course}</span>
             </div>
           )}
           {hasValue(tooltip.description) && (
             <div className="planning-tooltip-row">
-              <Text size={14} className="planning-tooltip-icon text-fuchsia-300" />
-              <span className="planning-tooltip-tag planning-tooltip-tag--fuchsia">Description</span>
-              <span className="planning-tooltip-value">{tooltip.description}</span>
+              <Text
+                size={14}
+                className="planning-tooltip-icon text-fuchsia-300"
+              />
+              <span className="planning-tooltip-tag planning-tooltip-tag--fuchsia">
+                Description
+              </span>
+              <span className="planning-tooltip-value">
+                {tooltip.description}
+              </span>
             </div>
           )}
         </div>
       )}
+
+      {/* Modals */}
+      <DragDropConfirmModal
+        isOpen={dragDropConfirmOpen}
+        data={dragDropData}
+        isLoading={dragDropLoading}
+        error={dragDropError ?? null}
+        onConfirm={onConfirmDragDrop ?? (() => {})}
+        onCancel={onCancelDragDrop ?? (() => {})}
+      />
+
+      <SessionDetailsModal
+        isOpen={sessionDetailsOpen}
+        session={selectedSession ?? null}
+        onClose={onCloseSessionDetails ?? (() => {})}
+        onEdit={onEditSession ?? (() => {})}
+        onDelete={onDeleteSessionFromDetails ?? (() => {})}
+      />
+
+      <AddSessionModal
+        isOpen={addSessionOpen}
+        onClose={onCloseAddSession ?? (() => {})}
+        defaultGroupId=""
+        defaultDate={addSessionDefaultDate}
+        defaultDateRange={addSessionDateRange}
+        onAdd={onAddSession ?? (async () => false)}
+      />
+
+      <EditSessionModal
+        isOpen={editSessionOpen}
+        session={editTarget ?? null}
+        onClose={onCloseEditSession ?? (() => {})}
+        onEdit={onEditSession2 ?? (async () => false)}
+      />
+
+      <DeleteSessionModal
+        isOpen={deleteConfirmOpen}
+        session={deleteTarget ?? null}
+        onClose={onCloseDeleteConfirm ?? (() => {})}
+        onConfirm={onConfirmDelete ?? (() => {})}
+      />
     </div>
   )
 }

--- a/src/components/planning/SessionDetailsModal.tsx
+++ b/src/components/planning/SessionDetailsModal.tsx
@@ -1,0 +1,174 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { XMarkIcon, PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline'
+import Button from '@/components/Button'
+import {
+  type SessionWithGroup,
+  SESSION_TYPE_LABELS,
+  SESSION_MODE_LABELS,
+} from '@/types/session'
+
+interface SessionDetailsModalProps {
+  isOpen: boolean
+  session: SessionWithGroup | null
+  onClose: () => void
+  onEdit: (session: SessionWithGroup) => void
+  onDelete: (session: SessionWithGroup) => void
+}
+
+function formatDateTime(iso: string) {
+  const d = new Date(iso)
+  return d.toLocaleDateString('fr-FR', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function SessionDetailsModal({
+  isOpen,
+  session,
+  onClose,
+  onEdit,
+  onDelete,
+}: SessionDetailsModalProps) {
+  return (
+    <AnimatePresence>
+      {isOpen && session && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 p-6 max-h-[90vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-xl font-bold text-gray-900">
+                Détails de la séance
+              </h2>
+
+              <button
+                onClick={onClose}
+                className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
+              >
+                <XMarkIcon className="size-5" />
+              </button>
+            </div>
+
+            <div className="border-t border-gray-200 pt-4 space-y-4">
+              {/* Type */}
+              <div className="border-l-4 border-indigo-500 pl-3">
+                <p className="text-xs font-semibold text-gray-500 uppercase mb-1">
+                  Type
+                </p>
+                <p className="text-sm text-gray-900 font-medium">
+                  {SESSION_TYPE_LABELS[session.type]}
+                </p>
+              </div>
+
+              {/* Mode */}
+              <div className="border-l-4 border-blue-500 pl-3">
+                <p className="text-xs font-semibold text-gray-500 uppercase mb-1">
+                  Mode
+                </p>
+                <p className="text-sm text-gray-900 font-medium">
+                  {SESSION_MODE_LABELS[session.mode]}
+                </p>
+              </div>
+
+              {/* Course */}
+              {session.course && (
+                <div className="border-l-4 border-teal-500 pl-3">
+                  <p className="text-xs font-semibold text-gray-500 uppercase mb-1">
+                    Module
+                  </p>
+                  <p className="text-sm text-gray-900 font-medium">
+                    {session.course}
+                  </p>
+                </div>
+              )}
+
+              {/* Group */}
+              {session.groupName && (
+                <div className="border-l-4 border-emerald-500 pl-3">
+                  <p className="text-xs font-semibold text-gray-500 uppercase mb-1">
+                    Groupe
+                  </p>
+                  <p className="text-sm text-gray-900 font-medium">
+                    {session.groupName}
+                  </p>
+                </div>
+              )}
+
+              {/* Room */}
+              {session.room && (
+                <div className="border-l-4 border-rose-500 pl-3">
+                  <p className="text-xs font-semibold text-gray-500 uppercase mb-1">
+                    Salle
+                  </p>
+                  <p className="text-sm text-gray-900 font-medium">
+                    {session.room}
+                  </p>
+                </div>
+              )}
+
+              {/* Date */}
+              <div className="border-l-4 border-violet-500 pl-3">
+                <p className="text-xs font-semibold text-gray-500 uppercase mb-1">
+                  Date
+                </p>
+                <p className="text-sm text-gray-900 font-medium">
+                  {formatDateTime(session.startDateTime)}
+                </p>
+              </div>
+
+              {/* Description */}
+              {session.description && (
+                <div className="border-l-4 border-fuchsia-500 pl-3">
+                  <p className="text-xs font-semibold text-gray-500 uppercase mb-1">
+                    Description
+                  </p>
+                  <p className="text-sm text-gray-700 whitespace-pre-wrap break-words">
+                    {session.description}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className="flex gap-3 pt-4 border-t border-gray-200">
+             
+
+              <button
+                onClick={() => onEdit(session)}
+                className="flex-1 flex items-center justify-center gap-2 border border-gray-300 text-primary-900 hover:bg-primary-50 rounded-md px-3 py-2 text-sm font-medium transition"
+              >
+                <PencilSquareIcon className="size-4" />
+                Modifier
+              </button>
+
+              <button
+                onClick={() => onDelete(session)}
+                className="flex-1 flex items-center justify-center gap-2 border border-gray-300 text-red-900 hover:bg-red-50 rounded-md px-3 py-2 text-sm font-medium transition"
+              >
+                <TrashIcon className="size-4" />
+                Supprimer
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/sessions/AddSessionModal.tsx
+++ b/src/components/sessions/AddSessionModal.tsx
@@ -19,6 +19,10 @@ interface AddSessionModalProps {
   onAdd: (values: AddSessionValues) => Promise<boolean>
   /** Préremplit le groupe (ex. groupe choisi sur la page) */
   defaultGroupId?: string
+  /** Préremplit la date de début (ex. double-click sur un slot) */
+  defaultDate?: Date | null
+  /** Préremplit la plage de temps (ex. heure de début et fin) */
+  defaultDateRange?: { start: Date; end: Date } | null
 }
 
 export default function AddSessionModal({
@@ -26,6 +30,8 @@ export default function AddSessionModal({
   onClose,
   onAdd,
   defaultGroupId = '',
+  defaultDate = null,
+  defaultDateRange = null,
 }: AddSessionModalProps) {
   const form = useAddSessionForm(async (values) => {
     const ok = await onAdd(values)
@@ -37,6 +43,32 @@ export default function AddSessionModal({
       form.setFieldValue('groupId', defaultGroupId)
     }
   }, [isOpen, defaultGroupId, form])
+
+  useEffect(() => {
+    if (isOpen && defaultDate) {
+      const dateStr = defaultDate.toISOString().split('T')[0]
+      form.setFieldValue('startDate', dateStr)
+      form.setFieldValue('endDate', dateStr)
+    }
+  }, [isOpen, defaultDate, form])
+
+  useEffect(() => {
+    if (isOpen && defaultDateRange) {
+      const startDateStr = defaultDateRange.start.toISOString().split('T')[0]
+      const startTimeStr = defaultDateRange.start
+        .toISOString()
+        .split('T')[1]
+        .slice(0, 5)
+
+      const endDateStr = defaultDateRange.end.toISOString().split('T')[0]
+      const endTimeStr = defaultDateRange.end.toISOString().split('T')[1].slice(0, 5)
+
+      form.setFieldValue('startDate', startDateStr)
+      form.setFieldValue('startTime', startTimeStr)
+      form.setFieldValue('endDate', endDateStr)
+      form.setFieldValue('endTime', endTimeStr)
+    }
+  }, [isOpen, defaultDateRange, form])
 
   const courseOptions = useCourseOptions()
   const groupOptions = useGroupOptions()

--- a/src/hooks/planning/usePlanningCalendarInteractions.ts
+++ b/src/hooks/planning/usePlanningCalendarInteractions.ts
@@ -1,0 +1,264 @@
+import { useState, useCallback, useRef } from 'react'
+import type { EventDropArg, EventClickArg, DateClickArg } from '@fullcalendar/core'
+import type { SessionResponse, SessionWithGroup } from '@/types/session'
+import { useSessionService } from '@/services/sessionService'
+
+interface DragDropData {
+  session: SessionResponse
+  originalStart: Date
+  originalEnd: Date
+  newStart: Date
+  newEnd: Date
+}
+
+interface PlanningCalendarInteractionsState {
+  // Drag & drop
+  dragDropConfirmOpen: boolean
+  dragDropData: DragDropData | null
+  dragDropLoading: boolean
+  dragDropError: string | null
+  // Session details
+  sessionDetailsOpen: boolean
+  selectedSession: SessionWithGroup | null
+  // Add session
+  addSessionOpen: boolean
+  addSessionDefaultDate: Date | null
+  // Delete confirmation
+  deleteConfirmOpen: boolean
+  deleteTarget: SessionWithGroup | null
+}
+
+export function usePlanningCalendarInteractions(
+  sessions: SessionWithGroup[],
+  onSessionsChange?: () => void | Promise<void>,
+) {
+  const { updateSession, deleteSession } = useSessionService()
+  const lastClickRef = useRef<number>(0)
+
+  const [state, setState] = useState<PlanningCalendarInteractionsState>({
+    dragDropConfirmOpen: false,
+    dragDropData: null,
+    dragDropLoading: false,
+    dragDropError: null,
+    sessionDetailsOpen: false,
+    selectedSession: null,
+    addSessionOpen: false,
+    addSessionDefaultDate: null,
+    deleteConfirmOpen: false,
+    deleteTarget: null,
+  })
+
+  // Calculate duration in milliseconds
+  const calculateDuration = useCallback((start: Date, end: Date): number => {
+    return end.getTime() - start.getTime()
+  }, [])
+
+  // Format ISO datetime
+  const toISO = useCallback((date: Date): string => {
+    return date.toISOString().slice(0, 19)
+  }, [])
+
+  // Handle drag & drop
+  const handleEventDrop = useCallback(
+    (arg: EventDropArg) => {
+      const session = sessions.find((s) => s.id === arg.event.id)
+      if (!session || !arg.event.start || !arg.event.end) {
+        arg.revert()
+        return
+      }
+
+      const originalStart = new Date(session.startDateTime)
+      const originalEnd = new Date(session.endDateTime)
+      const duration = calculateDuration(originalStart, originalEnd)
+
+      // New times
+      const newStart = arg.event.start
+      const newEnd = new Date(newStart.getTime() + duration)
+
+      setState((prev) => ({
+        ...prev,
+        dragDropConfirmOpen: true,
+        dragDropData: {
+          session,
+          originalStart,
+          originalEnd,
+          newStart,
+          newEnd,
+        },
+      }))
+
+      // Save the event for potential revert
+      arg.revert()
+    },
+    [sessions, calculateDuration],
+  )
+
+  // Confirm drag & drop
+  const confirmDragDrop = useCallback(async () => {
+    if (!state.dragDropData) return
+
+    setState((prev) => ({ ...prev, dragDropLoading: true, dragDropError: null }))
+
+    try {
+      const { session, newStart, newEnd } = state.dragDropData
+
+      // Find course ID - retrieve from session's extended props if available
+      // We need to fetch the course ID from existing data
+      const courseId = session.id // We'll need to figure this out from the API
+
+      // For now, we'll make an educated guess - session has 'course' field
+      // We need to resolve it back to courseId
+      // Best approach: fetch the current session to get all needed fields
+
+      const updateData = {
+        startDateTime: toISO(newStart),
+        endDateTime: toISO(newEnd),
+        mode: session.mode,
+        sessionType: session.type,
+        courseId: '', // Will be populated via API
+        sessionStatus: session.status,
+        roomId: session.room || '', // Will be populated via API
+        description: session.description || '',
+      }
+
+      await updateSession(session.id, updateData)
+
+      setState((prev) => ({
+        ...prev,
+        dragDropConfirmOpen: false,
+        dragDropData: null,
+        dragDropLoading: false,
+      }))
+
+      // Refresh sessions
+      await onSessionsChange?.()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors de la mise à jour'
+      setState((prev) => ({
+        ...prev,
+        dragDropLoading: false,
+        dragDropError: message,
+      }))
+    }
+  }, [state.dragDropData, updateSession, toISO, onSessionsChange])
+
+  // Cancel drag & drop
+  const cancelDragDrop = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      dragDropConfirmOpen: false,
+      dragDropData: null,
+      dragDropError: null,
+    }))
+  }, [])
+
+  // Handle event click
+  const handleEventClick = useCallback(
+    (arg: EventClickArg) => {
+      const session = sessions.find((s) => s.id === arg.event.id)
+      if (!session) return
+
+      setState((prev) => ({
+        ...prev,
+        sessionDetailsOpen: true,
+        selectedSession: session,
+      }))
+    },
+    [sessions],
+  )
+
+  // Handle date click (with double-click detection)
+  const handleDateClick = useCallback((arg: DateClickArg) => {
+    const now = Date.now()
+    const isDoubleClick = now - lastClickRef.current < 300
+
+    if (isDoubleClick && arg.date) {
+      setState((prev) => ({
+        ...prev,
+        addSessionOpen: true,
+        addSessionDefaultDate: arg.date,
+      }))
+    }
+
+    lastClickRef.current = now
+  }, [])
+
+  // Close modals
+  const closeSessionDetails = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      sessionDetailsOpen: false,
+      selectedSession: null,
+    }))
+  }, [])
+
+  const closeAddSession = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      addSessionOpen: false,
+      addSessionDefaultDate: null,
+    }))
+  }, [])
+
+  const closeDeleteConfirm = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      deleteConfirmOpen: false,
+      deleteTarget: null,
+    }))
+  }, [])
+
+  // Open delete confirmation
+  const openDeleteConfirm = useCallback((session: SessionWithGroup) => {
+    setState((prev) => ({
+      ...prev,
+      deleteConfirmOpen: true,
+      deleteTarget: session,
+    }))
+  }, [])
+
+  // Handle delete
+  const handleDeleteSession = useCallback(async () => {
+    if (!state.deleteTarget) return
+
+    try {
+      await deleteSession(state.deleteTarget.id)
+      closeDeleteConfirm()
+      await onSessionsChange?.()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors de la suppression'
+      console.error(message)
+    }
+  }, [state.deleteTarget, deleteSession, closeDeleteConfirm, onSessionsChange])
+
+  return {
+    // State
+    dragDropConfirmOpen: state.dragDropConfirmOpen,
+    dragDropData: state.dragDropData,
+    dragDropLoading: state.dragDropLoading,
+    dragDropError: state.dragDropError,
+    sessionDetailsOpen: state.sessionDetailsOpen,
+    selectedSession: state.selectedSession,
+    addSessionOpen: state.addSessionOpen,
+    addSessionDefaultDate: state.addSessionDefaultDate,
+    deleteConfirmOpen: state.deleteConfirmOpen,
+    deleteTarget: state.deleteTarget,
+    // Event handlers
+    handleEventDrop,
+    handleEventClick,
+    handleDateClick,
+    // Drag & drop
+    confirmDragDrop,
+    cancelDragDrop,
+    // Session details
+    closeSessionDetails,
+    // Add session
+    closeAddSession,
+    // Delete
+    openDeleteConfirm,
+    closeDeleteConfirm,
+    handleDeleteSession,
+  }
+}

--- a/src/routes/planning/index.tsx
+++ b/src/routes/planning/index.tsx
@@ -5,13 +5,23 @@ import { useCurrentUser } from '@/hooks/api/useAuth'
 import { usePlanning, useMyPlanning } from '@/hooks/planning/usePlanning'
 import { getAccessToken } from '@/auth/storage'
 import type { PlanningFilters } from '@/types/planning'
+import type { EventDropArg, EventClickArg } from '@fullcalendar/core'
+import type { AddSessionValues } from '@/hooks/sessions/useAddSessionForm'
+import type { EditSessionValues } from '@/hooks/sessions/useEditSessionForm'
+import type { SessionWithGroup } from '@/types/session'
+import type { SelectOption } from '@/types/formation'
+import { useSessionService } from '@/services/sessionService'
+import { useToast } from '@/hooks/useToast'
+import { useCourseOptions } from '@/hooks/sessions/useCourseOptions'
+import { useRoomOptions } from '@/hooks/sessions/useRoomOptions'
+import Toast from '@/components/Toast'
 import MainMenuContainer from '@/layout/main-menu-layout/MainMenuContainer'
 import MainNavigator from '@/layout/main-menu-layout/MainNavigator'
 import MainPageContainer from '@/layout/main-menu-layout/MainPageContainer'
 import PageLayout from '@/layout/PageLayout'
 import { getInitialDate } from '@/utils/date.utils'
 import { createFileRoute } from '@tanstack/react-router'
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 
 export const Route = createFileRoute('/planning/')({
   component: RouteComponent,
@@ -42,6 +52,35 @@ function PlanningContent() {
   const [trackId, setTrackId] = useState('')
   const [groupId, setGroupId] = useState('')
 
+  // Interaction states
+  const [sessionDetailsOpen, setSessionDetailsOpen] = useState(false)
+  const [selectedSession, setSelectedSession] = useState<SessionWithGroup | null>(null)
+
+  const [addSessionOpen, setAddSessionOpen] = useState(false)
+  const [addSessionDefaultDate, setAddSessionDefaultDate] = useState<Date | null>(null)
+  const [addSessionDateRange, setAddSessionDateRange] = useState<{ start: Date; end: Date } | null>(null)
+
+  const [editSessionOpen, setEditSessionOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<SessionWithGroup | null>(null)
+
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<SessionWithGroup | null>(null)
+
+  const [dragDropConfirmOpen, setDragDropConfirmOpen] = useState(false)
+  const [dragDropData, setDragDropData] = useState<{
+    eventId: string
+    oldStart: Date
+    oldEnd: Date
+    newStart: Date
+    newEnd: Date
+  } | null>(null)
+  const [dragDropLoading, setDragDropLoading] = useState(false)
+
+  const { toast, showToast, hideToast } = useToast()
+  const { updateSession, deleteSession, getSessionById, createSession, getAttendsBySession, deleteAttend } = useSessionService()
+  const courseOptions = useCourseOptions()
+  const roomOptions = useRoomOptions()
+
   const hasToken = !!getAccessToken()
 
   const weekBounds = useMemo(() => getWeekBounds(selectedDate), [selectedDate])
@@ -65,6 +104,328 @@ function PlanningContent() {
   const personalQuery = useMyPlanning(filters, { enabled: fetchMyPlanning })
   const activeQuery = hasToken ? personalQuery : publicQuery
 
+  // Helper: Find option value by matching name (case-insensitive partial match)
+  const findOptionIdByName = useCallback(
+    (options: SelectOption[], name: string | null): string => {
+      if (!name) return ''
+      const lower = name.toLowerCase()
+      const match = options.find((o) => o.label.toLowerCase().includes(lower))
+      return match?.value ?? ''
+    },
+    [],
+  )
+
+  // Handle double-click to add session with date range
+  const handleDoubleClick = useCallback(
+    (startDate: Date, endDate: Date) => {
+      setAddSessionDateRange({ start: startDate, end: endDate })
+      setAddSessionOpen(true)
+    },
+    [],
+  )
+
+  // Handle drag & drop with confirmation (validate session first)
+ const handleEventDropForConfirmation = useCallback(
+  async (eventId, oldStart, oldEnd, newStart, newEnd) => {
+    const format = (d: Date) => {
+      const pad = (n: number) => String(n).padStart(2, '0')
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+    }
+
+    try {
+      const session = await getSessionById(eventId)
+
+      const courseId = findOptionIdByName(courseOptions, session.course)
+      const roomId = findOptionIdByName(roomOptions, session.room)
+
+      if (!courseId) throw new Error('Course introuvable')
+
+      // 🔥 TEST backend (validation réelle)
+      await updateSession(eventId, {
+        startDateTime: format(newStart),
+        endDateTime: format(newEnd),
+        mode: session.mode,
+        sessionType: session.type,
+        courseId,
+        sessionStatus: session.status,
+        roomId,
+        description: session.description || '',
+      })
+
+      // 🔁 rollback immédiat (remet ancienne valeur)
+      await updateSession(eventId, {
+        startDateTime: format(oldStart),
+        endDateTime: format(oldEnd),
+        mode: session.mode,
+        sessionType: session.type,
+        courseId,
+        sessionStatus: session.status,
+        roomId,
+        description: session.description || '',
+      })
+
+      // ✅ ouvrir modal seulement si OK
+      setDragDropData({
+        eventId,
+        oldStart,
+        oldEnd,
+        newStart,
+        newEnd,
+      })
+      setDragDropConfirmOpen(true)
+
+      return true
+    } catch (error: any) {
+      const message =
+        error?.response?.status === 409
+          ? 'Groupe / professeur / salle indisponible'
+          : 'Erreur lors du déplacement'
+
+      showToast(message, 'error')
+
+      return false
+    }
+  },
+  [
+    getSessionById,
+    updateSession,
+    showToast,
+    courseOptions,
+    roomOptions,
+    findOptionIdByName,
+  ],
+)
+
+  // Confirm drag & drop and update
+  const confirmDragDrop = useCallback(async () => {
+    if (!dragDropData) return
+
+    const { eventId, newStart, newEnd } = dragDropData
+
+    setDragDropLoading(true)
+
+    try {
+      const session = await getSessionById(eventId)
+
+      const courseId = findOptionIdByName(courseOptions, session.course)
+      const roomId = findOptionIdByName(roomOptions, session.room)
+
+      if (!courseId) throw new Error('Course introuvable')
+
+      const format = (d: Date) => {
+        const pad = (n: number) => String(n).padStart(2, '0')
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+      }
+
+      await updateSession(eventId, {
+        startDateTime: format(newStart),
+        endDateTime: format(newEnd),
+        mode: session.mode,
+        sessionType: session.type,
+        courseId,
+        sessionStatus: session.status,
+        roomId,
+        description: session.description || '',
+      })
+
+      showToast('Séance déplacée avec succès', 'success')
+      setDragDropConfirmOpen(false)
+      setDragDropData(null)
+      activeQuery.refetch?.()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors du déplacement'
+      showToast(message, 'error')
+    } finally {
+      setDragDropLoading(false)
+    }
+  }, [dragDropData, updateSession, getSessionById, showToast, activeQuery, courseOptions, roomOptions, findOptionIdByName])
+
+  // Cancel drag & drop
+  const cancelDragDrop = useCallback(() => {
+    setDragDropConfirmOpen(false)
+    setDragDropData(null)
+  }, [])
+
+  // Handle drag & drop
+  const handleEventDrop = useCallback(
+    async (arg: EventDropArg) => {
+      const eventId = arg.event.id
+      const newStart = arg.event.start
+      const newEnd = arg.event.end
+
+      if (!eventId || !newStart || !newEnd) {
+        arg.revert()
+        return
+      }
+
+      try {
+        const session = await getSessionById(eventId)
+
+        const courseId = findOptionIdByName(courseOptions, session.course)
+        const roomId = findOptionIdByName(roomOptions, session.room)
+
+        if (!courseId) throw new Error('Course introuvable')
+
+        const format = (d: Date) => {
+          const pad = (n: number) => String(n).padStart(2, '0')
+          return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+        }
+
+        await updateSession(eventId, {
+          startDateTime: format(newStart),
+          endDateTime: format(newEnd),
+          mode: session.mode,
+          sessionType: session.type,
+          courseId,
+          sessionStatus: session.status,
+          roomId,
+          description: session.description || '',
+        })
+
+        showToast('Séance déplacée avec succès', 'success')
+        activeQuery.refetch?.()
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Erreur lors du déplacement'
+        showToast(message, 'error')
+        arg.revert()
+      }
+    },
+    [updateSession, getSessionById, showToast, activeQuery, courseOptions, roomOptions, findOptionIdByName],
+  )
+
+
+
+  // Handle event click
+  const handleEventClick = useCallback(
+    async (arg: EventClickArg) => {
+      if (!arg.event.id) return
+
+      try {
+        const session = await getSessionById(arg.event.id)
+        setSelectedSession(session as SessionWithGroup)
+        setSessionDetailsOpen(true)
+      } catch (error) {
+        showToast('Erreur lors du chargement de la séance', 'error')
+      }
+    },
+    [getSessionById, showToast],
+  )
+
+  // Open edit from details
+  const handleEditFromDetails = useCallback((session: SessionWithGroup) => {
+    setSelectedSession(null)
+    setSessionDetailsOpen(false)
+    setEditTarget(session)
+    setEditSessionOpen(true)
+  }, [])
+
+  // Open delete from details
+  const handleDeleteFromDetails = useCallback((session: SessionWithGroup) => {
+    setSessionDetailsOpen(false)
+    setDeleteTarget(session)
+    setDeleteConfirmOpen(true)
+  }, [])
+
+  // Handle add session
+  const handleAddSession = useCallback(
+    async (values: AddSessionValues) => {
+      try {
+        const startDateTime = `${values.startDate}T${values.startTime}:00`
+        const endDateTime = `${values.endDate}T${values.endTime}:00`
+
+        const createData = {
+          startDateTime,
+          endDateTime,
+          mode: values.mode,
+          sessionType: values.sessionType,
+          courseId: values.courseId,
+          sessionStatus: 'PROGRAMME' as const,
+          roomId: values.roomId || '',
+          description: values.description,
+        }
+
+        console.log('[handleAddSession] Creating session', { payload: createData })
+
+        const createdSession = await createSession(createData)
+
+        console.log('[handleAddSession] Created successfully', { id: createdSession.id })
+
+        showToast('Séance créée avec succès', 'success')
+        setAddSessionOpen(false)
+        setAddSessionDefaultDate(null)
+        activeQuery.refetch?.()
+        return true
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Erreur lors de la création'
+        console.error('[handleAddSession] Error:', message, error)
+        showToast(message, 'error')
+        return false
+      }
+    },
+    [showToast, activeQuery, createSession],
+  )
+
+  // Handle edit session
+  const handleEditSession = useCallback(
+    async (values: EditSessionValues) => {
+      if (!editTarget) return false
+
+      try {
+        await updateSession(editTarget.id, {
+          startDateTime: `${values.startDate}T${values.startTime}:00`,
+          endDateTime: `${values.endDate}T${values.endTime}:00`,
+          mode: values.mode,
+          sessionType: values.sessionType,
+          courseId: values.courseId,
+          sessionStatus: 'PROGRAMME',
+          roomId: values.roomId,
+          description: values.description,
+        })
+
+        showToast('Séance modifiée avec succès', 'success')
+        setEditSessionOpen(false)
+        setEditTarget(null)
+        activeQuery.refetch?.()
+        return true
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Erreur lors de la modification'
+        showToast(message, 'error')
+        return false
+      }
+    },
+    [editTarget, showToast, activeQuery, updateSession],
+  )
+
+  // Handle delete session
+  const handleDeleteSession = useCallback(async () => {
+    if (!deleteTarget) return
+
+    try {
+      const attends = await getAttendsBySession(deleteTarget.id).catch(() => [])
+
+      for (const a of attends) {
+        if (a.groupId && a.sessionId) {
+          await deleteAttend(a.groupId, a.sessionId).catch(() => {})
+        }
+      }
+
+      await deleteSession(deleteTarget.id)
+
+      showToast('Séance supprimée avec succès', 'success')
+      setDeleteConfirmOpen(false)
+      setDeleteTarget(null)
+      activeQuery.refetch?.()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors de la suppression'
+      showToast(message, 'error')
+    }
+  }, [deleteTarget, deleteSession, showToast, activeQuery, getAttendsBySession, deleteAttend])
+
   return (
     <PageLayout className="flex flex-col">
       <PlanningHeader
@@ -80,7 +441,55 @@ function PlanningContent() {
         selectedDate={selectedDate}
         events={activeQuery.data ?? []}
         isLoading={activeQuery.isLoading}
+        onEventDrop={handleEventDrop}
+        onEventClick={handleEventClick}
+        onDoubleClick={handleDoubleClick}
+        onEventDropForConfirmation={handleEventDropForConfirmation}
+        dragDropConfirmOpen={dragDropConfirmOpen}
+        dragDropData={
+          dragDropData
+            ? {
+                originalStart: dragDropData.oldStart,
+                originalEnd: dragDropData.oldEnd,
+                newStart: dragDropData.newStart,
+                newEnd: dragDropData.newEnd,
+              }
+            : null
+        }
+        dragDropLoading={dragDropLoading}
+        dragDropError={null}
+        onConfirmDragDrop={confirmDragDrop}
+        onCancelDragDrop={cancelDragDrop}
+        sessionDetailsOpen={sessionDetailsOpen}
+        selectedSession={selectedSession}
+        onCloseSessionDetails={() => setSessionDetailsOpen(false)}
+        onEditSession={handleEditFromDetails}
+        onDeleteSessionFromDetails={handleDeleteFromDetails}
+        addSessionOpen={addSessionOpen}
+        addSessionDefaultDate={addSessionDefaultDate}
+        addSessionDateRange={addSessionDateRange}
+        onCloseAddSession={() => {
+          setAddSessionOpen(false)
+          setAddSessionDefaultDate(null)
+          setAddSessionDateRange(null)
+        }}
+        onAddSession={handleAddSession}
+        editSessionOpen={editSessionOpen}
+        editTarget={editTarget}
+        onCloseEditSession={() => {
+          setEditSessionOpen(false)
+          setEditTarget(null)
+        }}
+        onEditSession2={handleEditSession}
+        deleteConfirmOpen={deleteConfirmOpen}
+        deleteTarget={deleteTarget}
+        onCloseDeleteConfirm={() => {
+          setDeleteConfirmOpen(false)
+          setDeleteTarget(null)
+        }}
+        onConfirmDelete={handleDeleteSession}
       />
+      <Toast toast={toast} onClose={hideToast} />
     </PageLayout>
   )
 }


### PR DESCRIPTION
## Changes

- Added drag & drop functionality for session scheduling
- Implemented session creation directly from planning (double click)
- Added session update (edit modal)
- Added session deletion with confirmation
- Integrated toast feedback for all actions (success & error)
- Improved overall interaction flow for admin users

## Result

- Admin can fully manage sessions directly from the planning interface
- Faster scheduling workflow (create, move, edit, delete)
- Clear feedback and better UX during interactions